### PR TITLE
chore(local/test logging): do not console log in local/test environments

### DIFF
--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -25,18 +25,29 @@ describe('setLogger', () => {
     const testLogger = setLogger();
     expect(testLogger.level).toBe('debug');
   });
-  it('Local environment writes to file', async () => {
+  it('Local environment writes to files only', async () => {
     process.env.NODE_ENV = 'local';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const setLogger = require('./logger').setLogger;
 
     const testLogger = setLogger();
-    expect(testLogger.transports.length).toEqual(3);
-    expect(testLogger.transports[0].name).toBe('console');
+    expect(testLogger.transports.length).toEqual(2);
+    expect(testLogger.transports[0].name).toBe('file');
+    expect(testLogger.transports[0].filename).toBe('error.log');
     expect(testLogger.transports[1].name).toBe('file');
-    expect(testLogger.transports[1].filename).toBe('error.log');
-    expect(testLogger.transports[2].name).toBe('file');
-    expect(testLogger.transports[2].filename).toBe('all.log');
+    expect(testLogger.transports[1].filename).toBe('all.log');
+  });
+  it('Test environment writes to files only', async () => {
+    process.env.NODE_ENV = 'test';
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const setLogger = require('./logger').setLogger;
+
+    const testLogger = setLogger();
+    expect(testLogger.transports.length).toEqual(2);
+    expect(testLogger.transports[0].name).toBe('file');
+    expect(testLogger.transports[0].filename).toBe('error.log');
+    expect(testLogger.transports[1].name).toBe('file');
+    expect(testLogger.transports[1].filename).toBe('all.log');
   });
   it('Dev environment defaults to debug level', async () => {
     process.env.NODE_ENV = 'development';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -33,8 +33,11 @@ const fileLoggingTransports = [
 ];
 
 const transports = [
-  new winston.transports.Console(),
-  ...(isLocal || isTest ? fileLoggingTransports : []),
+  // for local and test envs, log to files
+  // otherwise, log to the console
+  ...(isLocal || isTest
+    ? fileLoggingTransports
+    : [new winston.transports.Console()]),
 ];
 
 export function setLogger(metadata: object = {}): Logger {


### PR DESCRIPTION
console logs in local/test environments make debugging tests tough (as the console is flooded with non-helpful http logs). this is an attempt to remove those logs for local and test environments only.

afaict (admittedly with very little research), it appears our typescript applications set `NODE_ENV=local` for our `app` container - which is the env used when running integration tests in the container (e.g. `docker compose exec app npm run test-integrations`).

will this change have any unintended consequences? i don't think so, as no `prod` or `dev` environments should be impacted.