### PR TITLE
Bump version to bypass last publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocket-tools/ts-logger",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Basic Typescript Logger",
   "author": "",
   "main": "dist/index.js",


### PR DESCRIPTION
I accidentally published sans build files and npm wouldn't let me pull it and npmjs wouldn't let me pull the release. Oops.

Just bumping version here.