### PR TITLE
Create LOG_LEVEL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 This repository contains a simple, baseline logger setup for use in various Typescript apps. It is meant to be extensible. It comes with an optional morgan middleware setup function as well, for logging HTTP requests and responses.
 
+## Default Behavior
+
+### LOG_LEVEL
+
+When environment LOG_LEVEL is set, it will be used as the winston log level.
+
+Levels:
+
+```typescript
+const levels = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  http: 3, // optional level for http req & resp logging
+  graphql: 4, // optional level for graphql req & resp logging
+  debug: 5,
+};
+```
+
 ## Example Usage
 
 ### Generic Setup

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains a simple, baseline logger setup for use in various Type
 
 ## Default Behavior
 
-### LOG_LEVEL
+### `LOG_LEVEL``
 
-When environment LOG_LEVEL is set, it will be used as the winston log level.
+When environment `LOG_LEVEL`` is set, it will be used as the winston log level.
 
 Levels:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@types/jest": "29.5.3",
+        "@types/node": "^20.5.7",
         "sinon": "15.2.0"
       }
     },
@@ -1893,9 +1894,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
-      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocket-tools/ts-logger",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Basic Typescript Logger",
   "author": "",
   "main": "dist/index.js",
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/jest": "29.5.3",
+    "@types/node": "^20.5.7",
     "sinon": "15.2.0"
   }
 }

--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -17,14 +17,6 @@ describe('createLogger', () => {
     process.env = defaultEnvs;
   });
 
-  it('Local environment defaults to debug level', async () => {
-    process.env.NODE_ENV = 'local';
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const createLogger = require('./logger').createLogger;
-
-    const testLogger = createLogger();
-    expect(testLogger.level).toBe('debug');
-  });
   it('Local environment writes to files only', async () => {
     process.env.NODE_ENV = 'local';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -60,31 +52,42 @@ describe('createLogger', () => {
     expect(testLogger.transports[0].name).toBe('console');
   });
 
-  describe('env LOG_LEVEL is undefined', () => {
-    beforeEach(() => () => {
-      delete process.env.LOG_LEVEL;
-    });
-
-    it('Dev environment defaults to debug level', async () => {
-      process.env.NODE_ENV = 'development';
+  describe('level', () => {
+    it('level is LOG_LEVEL when LOG_LEVEL is defined', () => {
+      process.env.LOG_LEVEL = 'debug';
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const createLogger = require('./logger').createLogger;
-
-      const testLogger = createLogger();
-      expect(testLogger.level).toBe('debug');
+      const logger = require('./logger').createLogger();
+      expect(logger.level).toEqual('debug');
     });
 
-    it('Non-dev and non-local defaults to http level', async () => {
-      const testLogger = createLogger();
-      expect(testLogger.level).toBe('info');
-    });
-  });
+    describe('when env LOG_LEVEL is undefined', () => {
+      beforeEach(() => () => {
+        delete process.env.LOG_LEVEL;
+      });
 
-  it('sets log level from env LOG_LEVEL', () => {
-    process.env.LOG_LEVEL = 'debug';
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const logger = require('./logger').createLogger();
-    expect(logger.level).toEqual('debug');
+      it('level is debug when NODE_ENV is development', async () => {
+        process.env.NODE_ENV = 'development';
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const createLogger = require('./logger').createLogger;
+
+        const testLogger = createLogger();
+        expect(testLogger.level).toBe('debug');
+      });
+
+      it('level is info when NODE_ENV is not in (local, development)', async () => {
+        const testLogger = createLogger();
+        expect(testLogger.level).toBe('info');
+      });
+
+      it('level is debug when NODE_ENV is local ', async () => {
+        process.env.NODE_ENV = 'local';
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const createLogger = require('./logger').createLogger;
+
+        const testLogger = createLogger();
+        expect(testLogger.level).toBe('debug');
+      });
+    });
   });
 
   it('Non-dev and non-local do not write to file', async () => {

--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -1,10 +1,10 @@
-import { setLogger } from './logger';
+import { createLogger, setLogger } from './logger';
 import sinon from 'sinon';
 
 const defaultEnvs = process.env;
 
-describe('setLogger', () => {
-  const logger = setLogger();
+describe('createLogger', () => {
+  const logger = createLogger();
   const loggerInfoSpy = sinon.spy(logger, 'info');
 
   beforeEach(() => {
@@ -20,17 +20,17 @@ describe('setLogger', () => {
   it('Local environment defaults to debug level', async () => {
     process.env.NODE_ENV = 'local';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
+    const createLogger = require('./logger').createLogger;
 
-    const testLogger = setLogger();
+    const testLogger = createLogger();
     expect(testLogger.level).toBe('debug');
   });
   it('Local environment writes to files only', async () => {
     process.env.NODE_ENV = 'local';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
+    const createLogger = require('./logger').createLogger;
 
-    const testLogger = setLogger();
+    const testLogger = createLogger();
     expect(testLogger.transports.length).toEqual(2);
     expect(testLogger.transports[0].name).toBe('file');
     expect(testLogger.transports[0].filename).toBe('error.log');
@@ -40,51 +40,63 @@ describe('setLogger', () => {
   it('Test environment writes to files only', async () => {
     process.env.NODE_ENV = 'test';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
+    const createLogger = require('./logger').createLogger;
 
-    const testLogger = setLogger();
+    const testLogger = createLogger();
     expect(testLogger.transports.length).toEqual(2);
     expect(testLogger.transports[0].name).toBe('file');
     expect(testLogger.transports[0].filename).toBe('error.log');
     expect(testLogger.transports[1].name).toBe('file');
     expect(testLogger.transports[1].filename).toBe('all.log');
   });
-  it('Dev environment defaults to debug level', async () => {
-    process.env.NODE_ENV = 'development';
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
 
-    const testLogger = setLogger();
-    expect(testLogger.level).toBe('debug');
-  });
   it('Dev environment does not write to file', async () => {
     process.env.NODE_ENV = 'development';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
+    const createLogger = require('./logger').createLogger;
 
-    const testLogger = setLogger();
+    const testLogger = createLogger();
     expect(testLogger.transports.length).toEqual(1);
     expect(testLogger.transports[0].name).toBe('console');
   });
-  it('Non-dev and non-local defaults to http level', async () => {
-    const testLogger = setLogger();
-    expect(testLogger.level).toBe('info');
+
+  describe('env LOG_LEVEL is undefined', () => {
+    beforeEach(() => () => {
+      delete process.env.LOG_LEVEL;
+    });
+
+    it('Dev environment defaults to debug level', async () => {
+      process.env.NODE_ENV = 'development';
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const createLogger = require('./logger').createLogger;
+
+      const testLogger = createLogger();
+      expect(testLogger.level).toBe('debug');
+    });
+
+    it('Non-dev and non-local defaults to http level', async () => {
+      const testLogger = createLogger();
+      expect(testLogger.level).toBe('info');
+    });
   });
+
+  it('sets log level from env LOG_LEVEL', () => {
+    process.env.LOG_LEVEL = 'debug';
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const logger = require('./logger').createLogger();
+    expect(logger.level).toEqual('debug');
+  });
+
   it('Non-dev and non-local do not write to file', async () => {
     process.env.NODE_ENV = 'production';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
+    const createLogger = require('./logger').createLogger;
 
-    const testLogger = setLogger();
+    const testLogger = createLogger();
     expect(testLogger.transports.length).toEqual(1);
     expect(testLogger.transports[0].name).toBe('console');
   });
-  it('Can override log level', async () => {
-    const testLogger = setLogger();
-    expect(testLogger.level).toBe('info');
-    testLogger.level = 'warn';
-    expect(testLogger.level).toBe('warn');
-  });
+
   it('Logger has release SHA when present, null otherwise', async () => {
     logger.info('test');
     expect(loggerInfoSpy.calledOnce).toBeTruthy;
@@ -93,13 +105,43 @@ describe('setLogger', () => {
 
     process.env.RELEASE_SHA = '12345678910';
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const setLogger = require('./logger').setLogger;
-    const testLogger = setLogger();
+    const createLogger = require('./logger').createLogger;
+    const testLogger = createLogger();
     testLogger.info('test');
     expect(testLogger.defaultMeta).toHaveProperty('releaseSha');
     expect(testLogger.defaultMeta.releaseSha).toBe('12345678910');
   });
-  it('Cat additional default metadata', async () => {
+
+  it('has a null release sha when RELEASE_SHA is null', () => {
+    logger.info('test');
+    expect(loggerInfoSpy.calledOnce).toBeTruthy;
+    expect(logger.defaultMeta).toHaveProperty('releaseSha');
+    expect(logger.defaultMeta.releaseSha).toBeNull();
+  });
+
+  it('has a release sha when RELEASE_SHA is not null', () => {
+    process.env.RELEASE_SHA = '12345678910';
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const createLogger = require('./logger').createLogger;
+    const testLogger = createLogger();
+    testLogger.info('test');
+    expect(testLogger.defaultMeta).toHaveProperty('releaseSha');
+    expect(testLogger.defaultMeta.releaseSha).toBe('12345678910');
+  });
+
+  it('adds additional default metadata', () => {
+    const moreMeta = {
+      extra: 'fields',
+    };
+    const testLogger = createLogger({ defaultMeta: moreMeta });
+    expect(loggerInfoSpy.calledOnce).toBeTruthy;
+    expect(testLogger.defaultMeta).toHaveProperty('releaseSha');
+    expect(testLogger.defaultMeta.releaseSha).toBeNull();
+    expect(testLogger.defaultMeta).toHaveProperty('extra');
+    expect(testLogger.defaultMeta.extra).toBe('fields');
+  });
+
+  it('supports deprecated setLogger interface', () => {
     const moreMeta = {
       extra: 'fields',
     };


### PR DESCRIPTION
## Goal

Enable debugging in production environments without requiring code changes.

## Technical Decisions

Use `LOG_LEVEL` as a default log level if present.